### PR TITLE
use containers.dev template

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,11 +1,11 @@
-FROM mcr.microsoft.com/devcontainers/miniconda:0-3
+# https://github.com/devcontainers/templates/tree/main/src/miniconda
+FROM mcr.microsoft.com/devcontainers/miniconda:1-3
 
 # Copy environment.yml (if found) to a temp location so we update the environment. Also
 # copy "noop.txt" so the COPY instruction does not fail if no environment.yml exists.
-RUN conda install -n base -c conda-forge mamba
 COPY environment.yml* .devcontainer/noop.txt /tmp/conda-tmp/
-RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then umask 0002 && /opt/conda/bin/mamba env create -f /tmp/conda-tmp/environment.yml ; fi \
-    && rm -rf /tmp/conda-tmp
+RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then /opt/conda/bin/conda env update -n base -f /tmp/conda-tmp/environment.yml; fi \
+&& rm -rf /tmp/conda-tmp
 
 # [Optional] Uncomment to install a different version of Python than the default
 # RUN conda install -y python=3.6 \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,15 +13,9 @@
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": []
 
-	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "mamba init",
-
 	// Configure tool-specific properties.
 	"customizations": {
 		"vscode": {
-			"settings": {
-				"python.defaultInterpreterPath": "/opt/conda/envs/seasonality"
-			},
 			"extensions": [
 				"ms-python.python",
 				"ms-toolsai.jupyter",
@@ -30,9 +24,9 @@
 				"ms-azuretools.vscode-docker"
 			]
 		}
-	},
+	}
 
-	"postAttachCommand": "mamba activate seasonality"
+	// "postAttachCommand": "bash -c 'eval \"$(mamba shell hook --shell bash)\" && mamba activate seasonality'"
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"
 }


### PR DESCRIPTION
This pull request should address errors in building the codespaces. I switched to using [containers.dev](https://github.com/devcontainers) (since [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers/tree/main?tab=readme-ov-file) was archived).